### PR TITLE
typo in https://developers.ceramic.network/build/quick-start/

### DIFF
--- a/docs/build/quick-start.md
+++ b/docs/build/quick-start.md
@@ -276,7 +276,7 @@ Once you retrieve the desired commit, you can now create a document that is enfo
 === "Command"
 
     ```bash
-    $ ceramic ceramic create tile --content '{
+    $ ceramic create tile --content '{
         "title": "My first document with schema",
         "message": "Hello World"
       }' --schema k3y52l7qbv1frxu8co1hjrivem5cj2oiqtytlku3e4vjo92l67fkkvu6ywuzfxvy8


### PR DESCRIPTION
 In the create a document that uses a schema section fix typo 'ceramic ceramic' should be 'ceramic'

