### PR TITLE
Proposed changes to quick-start

### DIFF
--- a/docs/build/writes.md
+++ b/docs/build/writes.md
@@ -19,8 +19,7 @@ In this example we create a document where we set `doctype`, `content`, `schema`
 const doc = await ceramic.createDocument('tile', {
   content: { foo: "bar" },
   metadata: {
-    schema: "ceramic://kyz123...456",
-    controllers: ["did:3:kyz123...456"],
+    controllers: [ceramic.did.id],
     family: "doc family"
   }
 })


### PR DESCRIPTION
When attempting the quick-start with the `key-did-provider`, the example document write didn't work because the values for metadata.schema and metadata.controllers were invalid.