### PR TITLE
feat(docs): Update docs to cover how to set a DID instance for Ceramic to use

### DIFF
--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -3,7 +3,7 @@ This guide will help you add user authentication to your project. Authentication
 
 ## Prerequisites
 
-Authentication requires having [installed a Ceramic client](installation.md) in your project.
+Authentication requires having [configured a DID](configure-did.md) for your Ceramic client.
 
 ## Choose your setup
 
@@ -51,7 +51,7 @@ Install a DID wallet or provider in your project using npm.
     ```
 
 
-## Authentication
+## Create the Provider
 
 The authentication process varies depending on which wallet or provider you are using. Closely follow the steps below.
 
@@ -209,12 +209,20 @@ The authentication process varies depending on which wallet or provider you are 
     const provider = new Ed25519Provider(seed)
     ```
 
-## Set the provider
+## Set the Provider
 
-Set the authenticated provider instance to your Ceramic client in order to perform writes.
+Set the Provider instance to the DID instance used by your Ceramic client in order to perform writes.
 ``` javascript
-await ceramic.setDIDProvider(provider)
+ceramic.did.setProvider(provider)
 ```
+
+## Authenticate the DID
+Now all that's left is to authenticate to the Ceramic client's DID instance using the configured DID Provider. If you're using ThreeIdConnect, this step will cause a pop-up in your browser requesting permission to authenticate the DID.
+
+``` js
+await ceramic.did.authenticate()
+```
+
 
 ## Usage
 

--- a/docs/build/configure-did.md
+++ b/docs/build/configure-did.md
@@ -1,0 +1,56 @@
+# Configure your DID
+This guide will help you set up a DID instance to your Ceramic client so it can function properly. Ceramic clients require a DID instance and the DID Resolver(s) contained within to verify proper ownership of Ceramic streams by validating signatures on Ceramic Commits when loading a stream.
+
+## Prerequisites
+
+Configuring your DID requires having [installed a Ceramic client](installation.md) in your project.
+
+
+## Create the DID Resolver
+The DID Resolver allows Ceramic to look up information about any DID it encounters within
+any Stream it loads or interacts with. It therefore must be capable of resolving more DID
+methods than just what is used by the authenticated user. It is recommended that all Ceramic
+nodes be able to resolve at least the `did:3` and `did:key` DID methods.
+
+#### Import the resolvers
+
+Import Resolvers for all DID methods that this node will support
+
+``` javascript
+import KeyDidResolver from 'key-did-resolver'
+import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
+```
+
+#### Construct a ResolverRegistry of all desired Resolvers
+
+``` javascript
+const resolver = { ...KeyDidResolver.getResolver(),
+                   ...ThreeIdResolver.getResolver(ceramic) }
+```
+
+## Create the DID instance
+The DID instance wraps the DID Resolver (and optionally a DID Provider if you intend to [authenticate](authentication.md) your DID to allow writes).
+
+``` javascript
+import { DID } from 'dids'
+const did = new DID({ resolver })
+```
+
+## Set the DID instance on the Ceramic client
+
+Set the DID instance to your Ceramic client so that it can use it to resolve DIDs to validate
+ownership of Ceramic Streams.
+``` javascript
+ceramic.setDID(did)
+```
+
+## Authenticate the DID
+If you want to be able to perform writes with your Ceramic client, you will need to authenticate your DID first. To do that the DID must be provided a DID Provider instance. More information on how to do this is available on the [authenication](authentication.md) page.
+
+## Usage
+
+After setting the DID instance on the Ceramic client, the application will now be able to perform [reads](queries.md) on Ceramic. If the DID was [authenticated](authentication.md), then the user will also be able to perform [writes](writes.md) on Ceramic using their DID.
+
+</br>
+</br>
+</br>

--- a/docs/build/installation.md
+++ b/docs/build/installation.md
@@ -69,6 +69,9 @@ Setup your client within your project.
     const ceramic = new CeramicClient(API_URL)
     ```
 
+    #### Provide a DID instance to the Ceramic client.
+    Ceramic instances need access to a DID instance to use to resolve DIDs and to create and validate cryptographic signatures on Ceramic commits. See the [Configure your DID](configure-did.md) page for more information on how to do this.
+
 === "Core"
 
     #### Import the Core client
@@ -108,6 +111,9 @@ Setup your client within your project.
     ``` javascript
     const ceramic = await Ceramic.create(ipfs, config)
     ```
+
+    #### Provide a DID instance to the Ceramic client.
+    Ceramic instances need access to a DID instance to use to resolve DIDs and to create and validate cryptographic signatures on Ceramic commits. See the [Configure your DID](configure-did.md) page for more information on how to do this.
 
 === "CLI"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Build:
     - Quick Start: build/quick-start.md
     - Installation: build/installation.md
+    - Configure your DID: build/configure-did.md
     - Authentication: build/authentication.md
     - Writes: build/writes.md
     - Queries: build/queries.md


### PR DESCRIPTION
To break a circular dependency between Ceramic and the ThreeIdResolver, Ceramic no longer sets up a DID and Resolver automatically. Users must now do this themselves.