### PR TITLE
Add CAS mainnet info to hosting node page

### DIFF
--- a/docs/run/nodes/nodes.md
+++ b/docs/run/nodes/nodes.md
@@ -32,7 +32,7 @@ The following is an overview of the steps you must take to run a Ceramic node. D
     
     !!! info ""
 
-        Mainnet nodes will not run immediately after start up until your IP address is added to the allow list for the 3Box hosted anchor service and your PR is merged.
+        Mainnet nodes will not run immediately after start up until your IP address is added to the allow list for the 3Box hosted anchor service and your PR to the peerlist is merged.
 
 
 ## Running the Daemon

--- a/docs/run/nodes/nodes.md
+++ b/docs/run/nodes/nodes.md
@@ -28,12 +28,16 @@ The following is an overview of the steps you must take to run a Ceramic node. D
 
 4.  Staying Connected
 
-    Submit a pull request to the [Ceramic peerlist](https://github.com/ceramicnetwork/peerlist) with the multiaddress of your IPFS node, the IP address for your Ceramic node, and a description of the data persistence setup for the multiaddress, Ceramic State Store and IPFS Repo. Once your pull request is merged in you will be connected to the Ceramic network and the Ceramic Anchor Service.
+    Submit a pull request to the [Ceramic peerlist](https://github.com/ceramicnetwork/peerlist) with the multiaddress of your IPFS node, the IP address for your Ceramic node, and a description of the data persistence setup for the multiaddress, Ceramic State Store and IPFS Repo. Once your pull request is merged in you will be connected to the Ceramic network and the [Ceramic Anchor Service](https://github.com/ceramicnetwork/ceramic-anchor-service).
+    
+    !!! info ""
+
+        Mainnet nodes will not run immediately after start up until your IP address is added to the allow list for the 3Box hosted anchor service and your PR is merged.
 
 
 ## Running the Daemon
 
-The js-ceramic node is run as a daemon using Docker or Node.js. By default, Ceramic will run an in-process IPFS node on start and will connect to the Clay testnet.
+The js-ceramic node is run as a daemon using Docker or Node.js. By default, Ceramic will run an in-process IPFS node on start and will connect to the Clay testnet and the Ropsten [Ceramic Anchor Service](https://github.com/ceramicnetwork/ceramic-anchor-service).
 
 **Configuration**
 


### PR DESCRIPTION
Will hopefully address this comment we received in Discord

> small point to consider adding to the docs - might have been just me and maybe it should have been obvious, but I wasn't really tracking that once I pointed the node at the --elp network that there'd still be a delay while the PR was accepted and node was added to the approval list.  Spent about three hours learning far more than I wanted to know about CORS last night only to eventually realize nothing wrong with our setup.  Realize this is more on me than anyone else - but in interest of hopefully saving someone else of similar skill level some time - might be something to consider adding to the docs so expectations are clear.