### PR TITLE
Add tools overview page and IDX deprecation notice

### DIFF
--- a/docs/tools/glaze/datamodel.md
+++ b/docs/tools/glaze/datamodel.md
@@ -100,7 +100,14 @@ model.getSchemaURL('MySchema') // 'ceramic://mySchemaURL'
 
 - The DataModel tools and libraries are new and will likely go through breaking changes before stable versions are released.
 - Only Streams having all commits controlled by a Key DID (using the `did:key` method) are currently supported in DataModels.
+- Only Streams having no anchor commit are currently supported in DataModels in order to ensure portability across networks.
 - There is no update mechanims for Schema and Definitions yet, but this is something the tools should support over time.
+
+## Discovery
+
+There is currently no decentralized registry for DataModels, but it is a longer-term goal to make one available to help discovery and reusability.
+
+In the meantime, we encourage developers to share and discuss ideas for DataModels in the [DataModels registry available on GitHub](https://github.com/ceramicstudio/datamodels).
 
 ## Lifecycle
 

--- a/docs/tools/idx/overview.md
+++ b/docs/tools/idx/overview.md
@@ -1,5 +1,10 @@
 # IDX
 
+!!! warning "Deprecation notice"
+
+    :octicons-stop-16: The reference implementations for the Identity Index (IDX) specification are now provided by the [Glaze](../glaze/overview.md) and [Self.ID](../self-id/overview.md) projects.
+    The IDX libraries and CLI are deprecated in favor of these projects.
+
 [IDX](https://developers.idx.xyz){:target="\_blank"} is a decentralized identity protocol and JavaScript SDK that provides APIs which make it easy for developers to build applications with user-controlled [streams](../../learn/glossary.md#streams) for storing data, as well as to discover and make use of user data created on third-party applications. Building with IDX allows users to control their identities and data in a manner independent from any single application, while allowing developers to build data-rich applications without the liability of custodying user data on a centralized server or the poor user experience of forcing users to recreate the same data on every application.
 
 > This page mentions that IDX is intended for storing "user" data as that is its primary use case. However IDX can be used for storing data for other types of subjects represented by DIDs such as businesses, organizations, applications, assets (NFTs), or devices (IoT).

--- a/docs/tools/idx/overview.md
+++ b/docs/tools/idx/overview.md
@@ -2,7 +2,7 @@
 
 !!! warning "Deprecation notice"
 
-    :octicons-stop-16: The reference implementations for the Identity Index (IDX) specification are now provided by the [Glaze](../glaze/overview.md) and [Self.ID](../self-id/overview.md) projects.
+    :octicons-stop-16: The reference implementation for the Identity Index (IDX) specification is now provided by the [DID DataStore library](../glaze/did-datastore.md), notably used in the [Self.ID SDK](../self-id/overview.md).
     The IDX libraries and CLI are deprecated in favor of these projects.
 
 [IDX](https://developers.idx.xyz){:target="\_blank"} is a decentralized identity protocol and JavaScript SDK that provides APIs which make it easy for developers to build applications with user-controlled [streams](../../learn/glossary.md#streams) for storing data, as well as to discover and make use of user data created on third-party applications. Building with IDX allows users to control their identities and data in a manner independent from any single application, while allowing developers to build data-rich applications without the liability of custodying user data on a centralized server or the poor user experience of forcing users to recreate the same data on every application.

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -18,7 +18,7 @@ Self.ID is both a **reference application** and a **SDK** providing higher-level
 
 IDX refers to both the [Identity Index specification](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-11/CIP-11.md) and a set of tools (libraries and CLI).
 
-While the specification is still current, the IDX tools are now **deprecated** in favor of Glaze and Self.ID presented above.
+While the specification is still actively used, the IDX SDK and tools are now **deprecated** in favor of Glaze and Self.ID presented above.
 
 [IDX overview](idx/overview.md){: .md-button }
 

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -1,0 +1,29 @@
+# Tools
+
+Various tools such as libraries, CLIs and services are created on top of Ceramic to provide abstractions and specific solutions to some common use-cases.
+
+## Glaze
+
+The Glaze umbrella includes projects providing **low-level solutions** on top of Ceramic. Each project focuses on a specific scope, using a restricted number of dependencies on top of Ceramic.
+
+[Glaze overview](glaze/overview.md){: .md-button }
+
+## Self.ID
+
+Self.ID is both a **reference application** and a **SDK** providing higher-level abstractions to create user-centric Web applications. It leverages Glaze projects and [3ID Connect](../authentication/3id-did/3id-connect.md) to offer a simple way to help Web developers get started with the Ceramic ecosystem.
+
+[Self.ID overview](self-id/overview.md){: .md-button }
+
+## IDX
+
+IDX refers to both the [Identity Index specification](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-11/CIP-11.md) and a set of tools (libraries and CLI).
+
+While the specification is still current, the IDX tools are now **deprecated** in favor of Glaze and Self.ID presented above.
+
+[IDX overview](idx/overview.md){: .md-button }
+
+## IdentityLink
+
+IdentityLink is a service that issues verifiable claims which prove that a DID owns one or more Web2 social accounts.
+
+[IdentityLink overview](identitylink/overview.md){: .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
           - Overview: streamtypes/caip-10-link/overview.md
           - API: streamtypes/caip-10-link/api.md
   - Tools:
+      - Overview: tools/overview.md
       - Glaze:
           - Overview: tools/glaze/overview.md
           - Glossary: tools/glaze/glossary.md


### PR DESCRIPTION
Also adds a link to the datamodels registry now that it's up.