### PR TITLE
Setup analytics and cookie consent using mkdocs insiders

### DIFF
--- a/docs/pages/3boxlabs-privacy-policy.md
+++ b/docs/pages/3boxlabs-privacy-policy.md
@@ -49,6 +49,8 @@ Cookies, tags, and similar technologies are small pieces of code placed on your 
 
 - **Do Not Track Requests.** Some web browsers or smartphones can set “Do Not Track” requests to block user activity from being tracked across web pages or devices. We do not recognize “Do Not Track” signals because there is no industry standard way to do so.
 
+[Change cookie settings](#__consent){ .md-button }
+
 ## USE OF PERSONAL INFORMATION
 
 We use the Personal Information we collect for:

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,5 +1,27 @@
 INHERIT: mkdocs.yml
 
+extra:
+  analytics:
+    provider: google
+    property: G-MP8QDL3LWK
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well as to measure the
+      effectiveness of our documentation and whether users find what they're searching for, in
+      accordance to our <a href="/pages/3boxlabs-terms-conditions/">Terms and Conditions</a> and
+      <a href="/pages/3boxlabs-privacy-policy/">Privacy Policy</a>. With your consent, you're helping
+      us to make our documentation better.
+  generator: false
+  # Social icons in footer
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ceramicnetwork/ceramic
+      name: Ceramicnetwork on Github
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/ceramicnetwork
+      name: Ceramicnetwork on Twitter
+
 theme:
   name: material
   custom_dir: overrides

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,9 @@ markdown_extensions:
       toc_depth: 3
 
 extra:
+  analytics:
+    provider: google
+    property: G-MP8QDL3LWK
   generator: false
   # Social icons in footer
   social:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -22,15 +22,3 @@
   <meta name="twitter:description" content="{{ config.site_description }}" />
   <meta name="twitter:image" content="https://developers.ceramic.network/images/image-ceramic-opengraph.png" />
 {% endblock %}
-
-{% block analytics %}
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-MP8QDL3LWK"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-        dataLayer.push(arguments);
-    }
-    gtag('js', new Date());
-    gtag('config', 'G-MP8QDL3LWK');
-</script>
-{% endblock %}


### PR DESCRIPTION
- Switches from using custom code in template to built-in mkdocs feature for setting analytics
- Adds cookie consent prompt with links to T&Cs and privacy policy pages
