### PR TITLE
Setup feedback icons

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -4,6 +4,21 @@ extra:
   analytics:
     provider: google
     property: G-MP8QDL3LWK
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve this page by using our 
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLScSf4k6CYDp8yN1tGW8IMtb_g_6p3OLcE60Avabe0zXkpBo8g/viewform?usp=pp_url&entry.1288700168={url}" target="_blank">
+            feedback form</a>.
   consent:
     title: Cookie consent
     description: >-


### PR DESCRIPTION
## Description

Adds feedback icons with Google Analytics event and link to Google Form when providing negative feedback.

## How Has This Been Tested?

- Checked network requests are sent when clicking the icons
- Checked Google Form submissions are received

Still waiting for data: reporting on feedback in Google Analytics, not seeing any event yet so I don't know if it's because of a bad config or because I'm only testing locally and not from the real domain.