### PR TITLE
Fix typo in nft-did.md

### DIFF
--- a/docs/docs/advanced/standards/accounts/nft-did.md
+++ b/docs/docs/advanced/standards/accounts/nft-did.md
@@ -81,7 +81,7 @@ Note: If you wish to build with NFT accounts, you need to ensure your users can 
 
 ---
 
-- Only [ERC-21](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens are supported at this time.
+- Only [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens are supported at this time.
 - Only Ethereum Rinkeby, Etherem mainnet, and Polygon networks are supported by default. If you need other networks, see the [nft-did-resolver README](https://github.com/ceramicnetwork/nft-did-resolver),
 and update network parameters and configuration of your Ceramic node. Notable, this config needs three additional [subgraphs](https://thegraph.com): for blocks, for ERC-721 and ERC-1155 tokens, and a "skew", which is a typical block time.
 


### PR DESCRIPTION
Change ERC-21 into ERC-721 as that is the spec that is referenced by the link.

# Change ERC-21 to ERC-721

## Description

Simple typo fix in the NFT DID nomenclature.

## How Has This Been Tested?

None.  Non-code related change

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
