### PR TITLE
add redirect for nft dids doc

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,7 +238,7 @@ plugins:
         'authentication/dids/3id.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect
         'authentication/dids/key.md': 'docs/advanced/standards/accounts/key-did.md' # v2 redirect
         'authentication/legacy/3id-connect-migration.md': 'pages/3box-migration.md' # v2 redirect
-        'authentication/nft-did/method/': 'docs/advanced/standards/accounts/nft-did/index.md' # link exists in the wild
+        'authentication/nft-did/method.md': 'docs/advanced/standards/accounts/nft-did.md' # link exists in the wild
         'reference/javascript/clients.md': 'build/javascript/http.md'
         'reference/javascript/did-resolvers.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect
         'reference/javascript/did-providers.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,7 +238,7 @@ plugins:
         'authentication/dids/3id.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect
         'authentication/dids/key.md': 'docs/advanced/standards/accounts/key-did.md' # v2 redirect
         'authentication/legacy/3id-connect-migration.md': 'pages/3box-migration.md' # v2 redirect
-        'authentication/nft-did/method/': 'docs/advanced/standards/accounts/nft-did/' # link exists in the wild
+        'authentication/nft-did/method/': 'docs/advanced/standards/accounts/nft-did/index.md' # link exists in the wild
         'reference/javascript/clients.md': 'build/javascript/http.md'
         'reference/javascript/did-resolvers.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect
         'reference/javascript/did-providers.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,6 +238,7 @@ plugins:
         'authentication/dids/3id.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect
         'authentication/dids/key.md': 'docs/advanced/standards/accounts/key-did.md' # v2 redirect
         'authentication/legacy/3id-connect-migration.md': 'pages/3box-migration.md' # v2 redirect
+        'authentication/nft-did/method/': 'docs/advanced/standards/accounts/nft-did/' # link exists in the wild
         'reference/javascript/clients.md': 'build/javascript/http.md'
         'reference/javascript/did-resolvers.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect
         'reference/javascript/did-providers.md': 'docs/advanced/standards/accounts/3id-did.md' # v2 redirect


### PR DESCRIPTION
# create redirect for outdated nft dids link - #PLAT-390

## Description

Some devs in the wild asked about a 404 at the URL https://developers.ceramic.network/authentication/nft-did/method/ 

## How Has This Been Tested?

ran `mkdocs serve` locally and verified the redirect from `http://localhost:8000/authentication/nft-did/method/` works.

## Definition of Done

Before submitting this PR, please make sure:

- [x ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [x ] My code follows conventions, is well commented, and easy to understand
- [x ] My code builds and tests pass without any errors or warnings
- [x ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [x ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties. # will do after the merge

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
