### PR TITLE
Fix header color CSS

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-:root {
+:root, [data-md-color-scheme="default"] {
   --md-primary-fg-color: #f87236;
   --md-accent-fg-color: #ff4f00;
 }


### PR DESCRIPTION
Seems the theming logic changed in a recent version of mkdocs-material, so the CSS rule needs to be more specific to be applied.