### PR TITLE
Update nodes.md

### DIFF
--- a/docs/run/nodes/nodes.md
+++ b/docs/run/nodes/nodes.md
@@ -264,7 +264,7 @@ The Ceramic daemon serves an HTTP API that clients use to interact with your Cer
 
 ### **Staying connected to IPFS**
 
-Ceramic nodes rely on IPFS for networking. IPFS nodes connect to each other using a Libp2p module called "switch" (aka "swarm"). This module operates over a websocket, on port `4011` by default. The websocket port must be accessible to the internet so your Ceramic node can be connected to the network.
+Ceramic nodes rely on IPFS for networking. IPFS nodes connect to each other using a Libp2p module called "switch" (aka "swarm"). This module operates over a websocket, on port `4001` by default, as well as port `4011`. The websocket port must be accessible to the internet so your Ceramic node can be connected to the network, i.e. not blocked by a firewall. In addition, the port must match the swarm address announced by IPFS.
 
 !!! warning ""
 


### PR DESCRIPTION
hey @smrz2001 following up on the feedback from shacha on Gitcoin that it should generally be port 4001 instead of 4011, with an additional caveat around not being blocked by a firewall + consistency with the swarm address announced by IPFS

> "API port on 5001 is fine, IPFS log says API server listening on /ip4/0.0.0.0/tcp/5001 and that should be internal-traffic only. Docs (https://developers.ceramic.network/run/nodes/nodes/#staying-connected-to-ipfs) says the swarm port is 4011 but it might be 4001 instead -- swarm port is the one that needs to be externally reachable"