### PR TITLE
Fixed grammatical errors in Docs/learn/welcome.md

### DIFF
--- a/docs/learn/features.md
+++ b/docs/learn/features.md
@@ -33,7 +33,7 @@ Ceramic uses the decentralized identifier (DID) standard for user accounts, whic
 
 ---
 
-The Ceramic network is decentralized and permissionless, allowing anyone in the world to spin up a node to provide storage, compute, and bandwidth resources to users and applications built on the network. Today there are no tokenized incentives for running Ceramic, but the community is exploring options.
+The Ceramic network is decentralized and permissionless, allowing anyone in the world to spin up a node to provide storage, computatoin power and bandwidth resources to users and applications built on the network. Today there are no tokenized incentives for running Ceramic, but the community is exploring options.
 
 ## **Scalability**
 

--- a/docs/learn/how-it-works.md
+++ b/docs/learn/how-it-works.md
@@ -4,9 +4,9 @@
 
 Ceramic decentralizes application databases, making data universally composable and reusable across applications. The network consists of three core parts:
 
-       A highly-scalable and decentralized infrastructure for data availability and consensus
-       marketplace of community-created data models
-       suite of standard APIs for storing, updating, and retrieving data from those models.
+       A highly-scalable and decentralized infrastructure for Data Availability and Consensus
+       Marketplace of community-created data models
+       Suite of standard APIs for storing, updating and retrieving data from those models.
 
 ## **Core components**
 

--- a/docs/learn/how-it-works.md
+++ b/docs/learn/how-it-works.md
@@ -2,7 +2,11 @@
 
 ---
 
-Ceramic decentralizes application databases, making data universally composable and reusable across applications. The network consists of three core parts: a highly-scalable, decentralized infrastructure for data availability and consensus, a marketplace of community-created data models, and a suite of standard APIs for storing, updating, and retrieving data from those models.
+Ceramic decentralizes application databases, making data universally composable and reusable across applications. The network consists of three core parts:
+
+       A highly-scalable and decentralized infrastructure for data availability and consensus
+       marketplace of community-created data models
+       suite of standard APIs for storing, updating, and retrieving data from those models.
 
 ## **Core components**
 

--- a/docs/learn/welcome.md
+++ b/docs/learn/welcome.md
@@ -26,7 +26,7 @@ Connect your app to Ceramic using a [**development framework**](../build/framewo
 
 ### **Operate the Ceramic network**
 
-Provide storage, compute, and bandwidth to the network by [**running a node**](../run/index.md).
+Ceramic Provides storage computation and bandwidth to the network by [**running a node**](../run/index.md).
 
 > Today there are no tokenized incentives for running a Ceramic node, but by running a node you can ensure the data for your app remains available while helping contribute to the network's decentralization.
 


### PR DESCRIPTION
The documentation has an error including an extra comma and one word that was ambiguous, I have enhanced that part with good english rules.

Thank you 