### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/build/cli/quick-start.md
+++ b/docs/build/cli/quick-start.md
@@ -36,7 +36,7 @@ The Glaze CLI can be used to create a key DID, generating a 32-byte random seed:
 glaze did:create
 ```
 
-The expected output will be similar to the following, with `...` used as placeholder for brievety:
+The expected output will be similar to the following, with `...` used as placeholder for brevity:
 
 ```sh
 ✔ Created DID did:key:z6Mk... with seed ab...f0
@@ -48,6 +48,8 @@ The seed can then be used when running other commands:
 glaze [command] --key=ab...f0
 DID_KEY=ab...f0 glaze [command]
 ```
+
+**Note:** when entering your --key here, it refers to the encoded seed generated for the private key, not the did:key itself.
 
 ## **4. Create a stream**
 


### PR DESCRIPTION
# Clarify CLI Quickstart about using did:key seed

## Description

Two developers on the [forum](https://forum.ceramic.network/t/problem-on-creating-a-stream/343/4) were not clear that the --key refers to the seed value, not the did:key itself.