### PR TITLE
Deprecate 3id

### DIFF
--- a/docs/docs/advanced/standards/accounts/3id-did.md
+++ b/docs/docs/advanced/standards/accounts/3id-did.md
@@ -1,5 +1,11 @@
 # **3ID DID Accounts**
 
+---
+⚠️ ⚠️ ⚠️ The 3ID DID Method has been deprecated. Please use DID PKH using [DID Session](https://did.js.org/docs/authorization)! ⚠️ ⚠️ ⚠️
+
+---
+
+
 The 3ID DID Method (CIP-79) is a Ceramic-native account which can be used to authenticate to Ceramic to perform transactions on streams. 
 
 

--- a/docs/docs/advanced/standards/accounts/index.md
+++ b/docs/docs/advanced/standards/accounts/index.md
@@ -13,8 +13,8 @@ Below find the decentralized identifier (DID) standards currently supported as u
 | NAME                                | DESCRIPTION                                                                                                                       | Status            |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | [DID PKH (CIP-79)](https://did.js.org)    | A Ceramic account that natively supports blockchain accounts, default usage with did-session allows capabality and session usage  | ✅ Production     |
-| [3ID DID (CIP-79)](./3id-did.md)    | A Ceramic-native account that supports mutations in the DID Document, enabling the association of multiple wallets to the account | ✅ Production     |
 | [Key DID](./key-did.md)             | A Ceramic account that can only be associated with one wallet, which can never be changed                                         | ✅ Production     |
+| [3ID DID (CIP-79)](./3id-did.md)    | A Ceramic-native account that supports mutations in the DID Document, enabling the association of multiple wallets to the account | ⛔️ Deprecated     |
 | [NFT DID (CIP-94)](./nft-did.md)    | A Ceramic account that can be controlled by the current owner of a given NFT (non-fungible token)                                 | ⚠️ _Experimental_ |
 | [Safe DID (CIP-101)](./safe-did.md) | A Ceramic account that can be controlled by the current members of a Gnosis Safe smart contract                                   | ⚠️ _Experimental_ |
 

--- a/docs/reference/accounts/3id-did.md
+++ b/docs/reference/accounts/3id-did.md
@@ -1,6 +1,10 @@
 # **3ID DID libraries**
 
 ---
+⚠️ ⚠️ ⚠️ The 3ID DID Method has been deprecated. Please use DID PKH using [DID Session](https://did.js.org/docs/authorization)! ⚠️ ⚠️ ⚠️
+
+---
+
 
 The 3ID DID libraries provide support for the `did:3` method as a Ceramic account, which notably uses Ceramic to store DID documents as Ceramic streams, enabling features such as supporting multiple authentication keys and rotating these keys.
 


### PR DESCRIPTION
A lot of people are getting confused by the fact that 3ID is promoted in our docs. This PR adds deprecation warnings.